### PR TITLE
菜单上下颠倒BUG修复

### DIFF
--- a/app/generic.c
+++ b/app/generic.c
@@ -72,7 +72,7 @@ void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld) {
             gWasFKeyPressed = !gWasFKeyPressed; // toggle F function
 #ifdef ENABLE_TURN
 
-            turn_flag = 1;
+            turn_flag = gWasFKeyPressed;
 #endif
             if (gWasFKeyPressed)
                 gKeyInputCountdown = key_input_timeout_500ms;


### PR DESCRIPTION
连按两次F键后再按EXIT键，此时不在`F`状态但是也会调整菜单上下颠倒