### PR TITLE
Fix f+exit bug and #149

### DIFF
--- a/app/generic.c
+++ b/app/generic.c
@@ -72,7 +72,7 @@ void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld) {
             gWasFKeyPressed = !gWasFKeyPressed; // toggle F function
 #ifdef ENABLE_TURN
 
-            turn_flag = 1;
+            turn_flag = gWasFKeyPressed;
 #endif
             if (gWasFKeyPressed)
                 gKeyInputCountdown = key_input_timeout_500ms;

--- a/app/menu.c
+++ b/app/menu.c
@@ -1703,6 +1703,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
             gFlagAcceptSetting = false;
             gIsInSubMenu = false;
             gAskForConfirmation = 0;
+            edit_index = -1;
         } else {
             gFlagAcceptSetting = false;
             gAskForConfirmation = 0;
@@ -1808,6 +1809,7 @@ UI_MENU_GetCurrentMenuId() == MENU_MDC_ID
                     gFlagAcceptSetting = true;
                     gIsInSubMenu = false;
                     gAskForConfirmation = 0;
+                    edit_index = -1;
             }
         } else {
             gFlagAcceptSetting = true;


### PR DESCRIPTION
1. 连按两次F键，此时不在`F`状态，再按EXIT键也会调整菜单上下颠倒
2. 修复 #149