### PR TITLE
Fix f+exit bug and #149

### DIFF
--- a/app/app.c
+++ b/app/app.c
@@ -1512,6 +1512,12 @@ if (gDTMF_IsTx && gDTMF_TxStopCountdown_500ms > 0 && --gDTMF_TxStopCountdown_500
     gUpdateDisplay = true;
 }
 #endif
+
+#ifdef ENABLE_TURN
+    if(turn_flag && !gWasFKeyPressed){
+        turn_flag = 0;
+    }
+#endif
 }
 
 #if defined(ENABLE_ALARM) || defined(ENABLE_TX1750)

--- a/app/generic.c
+++ b/app/generic.c
@@ -72,7 +72,7 @@ void GENERIC_Key_F(bool bKeyPressed, bool bKeyHeld) {
             gWasFKeyPressed = !gWasFKeyPressed; // toggle F function
 #ifdef ENABLE_TURN
 
-            turn_flag = 1;
+            turn_flag = gWasFKeyPressed;
 #endif
             if (gWasFKeyPressed)
                 gKeyInputCountdown = key_input_timeout_500ms;

--- a/app/menu.c
+++ b/app/menu.c
@@ -1754,6 +1754,7 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
                 gFlagAcceptSetting = false;
                 gIsInSubMenu = false;
                 gAskForConfirmation = 0;
+                edit_index = -1;
             } else {
                 gFlagAcceptSetting = false;
                 gAskForConfirmation = 0;
@@ -1808,6 +1809,7 @@ UI_MENU_GetCurrentMenuId() == MENU_MDC_ID
                     gFlagAcceptSetting = true;
                     gIsInSubMenu = false;
                     gAskForConfirmation = 0;
+                    edit_index = -1;
             }
         } else {
             gFlagAcceptSetting = true;


### PR DESCRIPTION
1. 修复 菜单上下颠倒 bug：连按两次F键再按EXIT键、F+数字键后再按EXIT键 等情况下也会调整菜单上下颠倒
2. 修复 #149