### PR TITLE
Fix pinyin bug and dtmf display bug

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs: #定义工作流程
             python-crcmod \
 
       - name: Checkout #拉取代码
-        uses: actions/checkout@v3 #使用 GitHub Actions 提供的 checkout 动作
+        uses: actions/checkout@v4 #使用 GitHub Actions 提供的 checkout 动作
 
       - name: safe.directory #设置 git 的 safe.directory 配置
         run: git config --global --add safe.directory /__w/uv-k5-firmware-custom/uv-k5-firmware-custom
@@ -30,7 +30,7 @@ jobs: #定义工作流程
         run: arm-none-eabi-size firmware #使用 arm-none-eabi-size 命令计算固件大小
 
       - name: Upload Artifact #上传固件文件
-        uses: actions/upload-artifact@v3 #使用 GitHub Actions 提供的 upload-artifact 动作
+        uses: actions/upload-artifact@v4 #使用 GitHub Actions 提供的 upload-artifact 动作
         with:
           name: firmware #设置 artifact 名称为 firmware
           path: LOSEHU*.bin #上传文件路径为 LOSEHU*.bin

--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -21,7 +21,7 @@ jobs: #定义工作流程
             python-requests
 
       - name: Checkout #拉取代码
-        uses: actions/checkout@v3 #使用 GitHub Actions 提供的 checkout 动作
+        uses: actions/checkout@v4 #使用 GitHub Actions 提供的 checkout 动作
 
       - name: safe.directory #设置 git 的 safe.directory 配置
         run: git config --global --add safe.directory /__w/uv-k5-firmware-custom/uv-k5-firmware-custom
@@ -37,7 +37,7 @@ jobs: #定义工作流程
             zip -j output/losehu.zip ./LOSEHU*.bin ./version.json ./function.json
 
       - name: Upload ALL #上传固件文件
-        uses: actions/upload-artifact@v3 #使用 GitHub Actions 提供的 upload-artifact 动作
+        uses: actions/upload-artifact@v4 #使用 GitHub Actions 提供的 upload-artifact 动作
         with:
           name: firmware_all #设置 artifact 名称为 firmware
           path: output/losehu.zip #上传文件路径为 LOSEHU*.bin

--- a/app/menu.c
+++ b/app/menu.c
@@ -103,8 +103,8 @@ void PINYIN_SOLVE(uint32_t tmp) {
     uint8_t tmp_PINYIN_SEARCH_NUM = PINYIN_SEARCH_NUM;
     uint8_t tmp_PINYIN_SEARCH_FOUND = PINYIN_SEARCH_FOUND;
 
-    PINYIN_SEARCH_INDEX = sear_pinyin_code(PINYIN_CODE, &PINYIN_SEARCH_NUM,
-                                           &PINYIN_SEARCH_FOUND);
+    PINYIN_SEARCH_INDEX = sear_pinyin_code(PINYIN_CODE, &PINYIN_SEARCH_NUM, &PINYIN_SEARCH_FOUND);
+
     if (PINYIN_SEARCH_INDEX == 255 && PINYIN_SEARCH_FOUND == 0) {
         PINYIN_CODE = tmp;
         PINYIN_CODE_INDEX *= 10;
@@ -114,15 +114,17 @@ void PINYIN_SOLVE(uint32_t tmp) {
         if (PINYIN_CODE_INDEX == 100000)INPUT_STAGE = 0;
     }
 
-        if (INPUT_STAGE) {//需要选拼音
+    if (INPUT_STAGE) {
+        //需要选拼音
         if (PINYIN_SEARCH_FOUND) {
-            if (PINYIN_SEARCH_INDEX != 255) {//确实存在这个拼音组合
+            if (PINYIN_SEARCH_INDEX != 255) {
+                //确实存在这个拼音组合
                 PINYIN_NOW_INDEX = PINYIN_SEARCH_INDEX;
                 PINYIN_NOW_NUM = PINYIN_SEARCH_NUM;
                 PINYIN_SEARCH_MODE = 1;
             }
-        } else //没有这个拼音组合但是有备选
-        {
+        } else {
+            //没有这个拼音组合但是有备选
 //            PINYIN_SEARCH_MODE = 2;
 //            PINYIN_NOW_INDEX = PINYIN_SEARCH_INDEX;
 //            PINYIN_NOW_NUM = PINYIN_SEARCH_NUM;
@@ -139,7 +141,6 @@ void PINYIN_SOLVE(uint32_t tmp) {
 //            }
         }
     }
-
 }
 #endif
 void MENU_CssScanFound(void) {
@@ -1301,7 +1302,7 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
                             uint32_t tmp = PINYIN_CODE;
                             PINYIN_CODE += Key * PINYIN_CODE_INDEX;
                             PINYIN_CODE_INDEX /= 10;
-                       PINYIN_SOLVE(tmp);
+                            PINYIN_SOLVE(tmp);
 
 //                            if(end_index>100)end_index=0;
                         } else if (INPUT_STAGE == 2) {
@@ -1309,9 +1310,9 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
                                     CHN_NOW_NUM - CHN_NOW_PAGE * 6 > 6 ? 6 : CHN_NOW_NUM - CHN_NOW_PAGE * 6;
                             if (Key > 0 && Key <= SHOW_NUM) {
                                 if (edit_chn[edit_index + 1] == 1)edit[edit_index + 2] = '_';
-                                EEPROM_ReadBuffer(CHN_NOW_ADD + CHN_NOW_PAGE * 6 * 2 + 2 * (Key - 1),&edit [ edit_index], 2);
+                                EEPROM_ReadBuffer(CHN_NOW_ADD + CHN_NOW_PAGE * 6 * 2 + 2 * (Key - 1), &edit[edit_index], 2);
                                 edit_index += 2;
-                                PINYIN_NUM_SELECT=0;
+                                PINYIN_NUM_SELECT = 0;
                                 PINYIN_CODE = 0;
                                 PINYIN_SEARCH_MODE = 0;
                                 INPUT_STAGE = 0;
@@ -1330,10 +1331,9 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
                             if (Key >= 1 && Key <= 2 *num_size[INPUT_SELECT - 2]) {//选择字母
                                 if (edit_chn[edit_index] == 1) edit[edit_index+1] = '_';
                                 if (Key > num_size[INPUT_SELECT - 2])
-                                    edit[edit_index] =
-                                            num_excel[INPUT_SELECT - 2][Key - 1 - num_size[INPUT_SELECT - 2]] -
-                                            32;
-                                else edit[edit_index] = num_excel[INPUT_SELECT - 2][Key - 1];
+                                    edit[edit_index] = num_excel[INPUT_SELECT - 2][Key - 1 - num_size[INPUT_SELECT - 2]] - 32;
+                                else
+                                    edit[edit_index] = num_excel[INPUT_SELECT - 2][Key - 1];
                                 if (++edit_index >= end_index) {    // exit edit
                                     //gFlagAcceptSetting = false;
                                     gAskForConfirmation = 1;
@@ -1512,6 +1512,7 @@ static void MENU_Key_EXIT(bool bKeyPressed, bool bKeyHeld) {
 
                 uint32_t tmp = PINYIN_CODE;
                 PINYIN_SEARCH_MODE=0;
+                PINYIN_NUM_SELECT = 0;
                 PINYIN_SOLVE(tmp);
 
             } else if (INPUT_STAGE == 2) {
@@ -1630,13 +1631,11 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
                         else PINYIN_NUM_SELECT = 0;
                         UPDATE_CHN();
                         return;
-
                     }
                 }
-            }else if(INPUT_MODE==3)
-                {
-                INPUT_MODE=INPUT_MODE_LAST;
-                }
+            } else if (INPUT_MODE == 3) {
+                INPUT_MODE = INPUT_MODE_LAST;
+            }
         }
     }
 
@@ -1681,11 +1680,10 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
         }
 #ifdef ENABLE_MDC1200
 #ifdef ENABLE_MDC1200_EDIT
-        if (UI_MENU_GetCurrentMenuId() == MENU_MDC_ID)
-    {
-                edit_index = 0;
+        if (UI_MENU_GetCurrentMenuId() == MENU_MDC_ID) {
+            edit_index = 0;
             memmove(edit_original, edit, sizeof(edit_original));
-    }
+        }
 #endif
 #endif
         return;
@@ -1735,16 +1733,11 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
 #endif
             if (edit_index < MAX_EDIT_INDEX) {
 #ifdef ENABLE_PINYIN
-
-
-
                 if (INPUT_MODE == 0 && edit_index + 1 >= MAX_EDIT_INDEX)
                     INPUT_MODE = 1;
 #endif
 
                 return;
-
-
             }
             // exit
             if (memcmp(edit_original, edit, sizeof(edit_original)) == 0) {    // no change - drop it

--- a/app/menu.c
+++ b/app/menu.c
@@ -1335,7 +1335,7 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
                                             32;
                                 else edit[edit_index] = num_excel[INPUT_SELECT - 2][Key - 1];
                                 if (++edit_index >= end_index) {    // exit edit
-                                    gFlagAcceptSetting = false;
+                                    //gFlagAcceptSetting = false;
                                     gAskForConfirmation = 1;
                                 }
                                 INPUT_STAGE = 0;
@@ -1345,14 +1345,14 @@ static void MENU_Key_0_to_9(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
                         if (edit_chn[edit_index])edit[edit_index + 1] = '_';
                         edit[edit_index] = '0' + Key;
                         if (++edit_index >= end_index) {    // exit edit
-                            gFlagAcceptSetting = false;
+                            //gFlagAcceptSetting = false;
                             gAskForConfirmation = 1;
                         }
                     }
 #else
                     edit[edit_index] = '0' + Key ;
                     if (++edit_index >= end_index) {    // exit edit
-                        gFlagAcceptSetting = false;
+                        //gFlagAcceptSetting = false;
                         gAskForConfirmation = 1;
                     }
 #endif
@@ -1700,13 +1700,10 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
 
         // exit
         if (memcmp(edit_original, edit, sizeof(edit_original)) == 0) {    // no change - drop it
-            gFlagAcceptSetting = false;
             gIsInSubMenu = false;
-            gAskForConfirmation = 0;
-        } else {
-            gFlagAcceptSetting = false;
-            gAskForConfirmation = 0;
         }
+        //gFlagAcceptSetting = false;
+        gAskForConfirmation = 0;
 
     }
 #endif
@@ -1751,14 +1748,10 @@ static void MENU_Key_MENU(const bool bKeyPressed, const bool bKeyHeld) {
             }
             // exit
             if (memcmp(edit_original, edit, sizeof(edit_original)) == 0) {    // no change - drop it
-                gFlagAcceptSetting = false;
                 gIsInSubMenu = false;
-                gAskForConfirmation = 0;
-                edit_index = -1;
-            } else {
-                gFlagAcceptSetting = false;
-                gAskForConfirmation = 0;
             }
+            //gFlagAcceptSetting = false;
+            gAskForConfirmation = 0;
         }
     }
 #ifdef ENABLE_PINYIN //退出输入模式
@@ -1809,7 +1802,6 @@ UI_MENU_GetCurrentMenuId() == MENU_MDC_ID
                     gFlagAcceptSetting = true;
                     gIsInSubMenu = false;
                     gAskForConfirmation = 0;
-                    edit_index = -1;
             }
         } else {
             gFlagAcceptSetting = true;
@@ -1840,7 +1832,7 @@ static void MENU_Key_STAR(const bool bKeyPressed, const bool bKeyHeld) {
 #ifndef ENABLE_PINYIN
             edit[edit_index] = '-';
             if (++edit_index >= MAX_EDIT_INDEX) {    // exit edit
-                gFlagAcceptSetting = false;
+                //gFlagAcceptSetting = false;
                 gAskForConfirmation = 1;
             }
 
@@ -2112,7 +2104,7 @@ void MENU_ProcessKeys(KEY_Code_t Key, bool bKeyPressed, bool bKeyHeld) {
 
 
                         if (++edit_index >= MAX_EDIT_INDEX) {    // exit edit
-                            gFlagAcceptSetting = false;
+                            //gFlagAcceptSetting = false;
                             gAskForConfirmation = 1;
                         }
 

--- a/ui/main.c
+++ b/ui/main.c
@@ -146,6 +146,7 @@ void UI_DisplayAudioBar(void) {
         gScreenToDisplay != DISPLAY_MAIN
 #ifdef ENABLE_DTMF_CALLING
         || gDTMF_CallState != DTMF_CALL_STATE_NONE
+        || gDTMF_IsTx
 #endif
             ) {
         return;  // screen is in use
@@ -164,19 +165,15 @@ void UI_DisplayAudioBar(void) {
 
     uint8_t *p_line = gFrameBuffer[line];
 #if ENABLE_CHINESE_FULL == 4 &&!defined(ENABLE_ENGLISH)
-    if(audio_keep_flag)
-        {
-//            audio_keep_flag=false;
+    if (audio_keep_flag) {
+        //audio_keep_flag=false;
 
 #ifndef ENABLE_AUDIO_BAR_DEFAULT
-
-       memset(p_line+35, 0, LCD_WIDTH-35);
+        memset(p_line + 35, 0, LCD_WIDTH - 35);
 #else
        memset(p_line+62, 0, LCD_WIDTH-62);
-
 #endif
-
-        }else
+    } else
 #endif
     memset(p_line, 0, LCD_WIDTH);
 
@@ -222,19 +219,19 @@ void DisplayRSSIBar(const bool now) {
 #ifdef ENABLE_DTMF_CALLING
         || gDTMF_CallState != DTMF_CALL_STATE_NONE
 #endif
-        )
-      {  return;     // display is in use
-}
-        if (now)
-        {memset(p_line, 0, LCD_WIDTH);
-}
+    ) {
+        return; // display is in use
+    }
+    if (now) {
+        memset(p_line, 0, LCD_WIDTH);
+    }
 
 
-const int16_t s0_dBm   = -gEeprom.S0_LEVEL;                  // S0 .. base level
+    const int16_t s0_dBm = -gEeprom.S0_LEVEL; // S0 .. base level
     const int16_t rssi_dBm =
         BK4819_GetRSSI_dBm()
 #ifdef ENABLE_AM_FIX
-+ ((gSetting_AM_fix && gRxVfo->Modulation == MODULATION_AM) ? AM_fix_get_gain_diff() : 0)
+        + ((gSetting_AM_fix && gRxVfo->Modulation == MODULATION_AM) ? AM_fix_get_gain_diff() : 0)
 #endif
         + dBmCorrTable[gRxVfo->Band];
 
@@ -243,16 +240,13 @@ const int16_t s0_dBm   = -gEeprom.S0_LEVEL;                  // S0 .. base level
     uint8_t overS9dBm = MIN(MAX(rssi_dBm + gEeprom.S9_LEVEL, 0), 99);
     uint8_t overS9Bars = MIN(overS9dBm/10, 4);
 
-    if(overS9Bars == 0) {
+    if (overS9Bars == 0) {
         sprintf(str, "% 4d S%d", rssi_dBm, s_level);
-    }
-    else {
+    } else {
         sprintf(str, "% 4d  %2d", rssi_dBm, overS9dBm);
-        memcpy(p_line + 2 + 7*5, &plus, ARRAY_SIZE(plus));
-
-
+        memcpy(p_line + 2 + 7 * 5, &plus, ARRAY_SIZE(plus));
     }
-UI_PrintStringSmall(str, 2, 0, line);
+    UI_PrintStringSmall(str, 2, 0, line);
     DrawLevelBar(bar_x, line, s_level + overS9Bars);
     if (now)
         ST7565_BlitLine(line);
@@ -409,12 +403,12 @@ void UI_DisplayMain(void) {
         if (activeTxVFO != vfo_num) // this is not active TX VFO
         {
 #ifdef ENABLE_SCAN_RANGES
-            if(gScanRangeStart) {
-                    UI_PrintStringSmall("ScnRng", 5, 0, line);
-                    sprintf(String, "%3u.%05u", gScanRangeStart / 100000, gScanRangeStart % 100000);
-                    UI_PrintStringSmall(String, 56, 0, line);
-                   sprintf(String, "%3u.%05u", gScanRangeStop / 100000, gScanRangeStop % 100000);
-                    UI_PrintStringSmall(String, 56, 0, line + 1);
+            if (gScanRangeStart) {
+                UI_PrintStringSmall("ScnRng", 5, 0, line);
+                sprintf(String, "%3u.%05u", gScanRangeStart / 100000, gScanRangeStart % 100000);
+                UI_PrintStringSmall(String, 56, 0, line);
+                sprintf(String, "%3u.%05u", gScanRangeStop / 100000, gScanRangeStop % 100000);
+                UI_PrintStringSmall(String, 56, 0, line + 1);
                 continue;
             }
 #endif
@@ -430,7 +424,7 @@ void UI_DisplayMain(void) {
                 // show DTMF stuff
 #ifdef ENABLE_DTMF_CALLING
                 char Contact[16];
-if (!gDTMF_InputMode) {
+                if (!gDTMF_InputMode) {
                     if (gDTMF_CallState == DTMF_CALL_STATE_CALL_OUT) {
                         pPrintStr = DTMF_FindContact(gDTMF_String, Contact) ? Contact : gDTMF_String;
                     } else if (gDTMF_CallState == DTMF_CALL_STATE_RECEIVED || gDTMF_CallState == DTMF_CALL_STATE_RECEIVED_STAY){
@@ -447,8 +441,8 @@ if (!gDTMF_InputMode) {
                     if (gDTMF_CallState == DTMF_CALL_STATE_CALL_OUT) {
                         pPrintStr = (gDTMF_State == DTMF_STATE_CALL_OUT_RSP) ? "CALL OUT(RSP)" : "CALL OUT";
                     } else if (gDTMF_CallState == DTMF_CALL_STATE_RECEIVED || gDTMF_CallState == DTMF_CALL_STATE_RECEIVED_STAY) {
-                  sprintf(String, "CALL FRM:%s", (DTMF_FindContact(gDTMF_Caller, Contact)) ? Contact : gDTMF_Caller);
-                  pPrintStr = String;
+                        sprintf(String, "CALL FRM:%s", (DTMF_FindContact(gDTMF_Caller, Contact)) ? Contact : gDTMF_Caller);
+                        pPrintStr = String;
                     } else if (gDTMF_IsTx) {
                         pPrintStr = (gDTMF_State == DTMF_STATE_TX_SUCC) ? "DTMF TX(SUCC)" : "DTMF TX";
                     }
@@ -505,22 +499,19 @@ if (!gDTMF_InputMode) {
         if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])) {    // channel mode
             const unsigned int x = 2;
             const bool inputting = gInputBoxIndex != 0 && gEeprom.TX_VFO == vfo_num;
-            if (!inputting)
-                last_rx_vfo == vfo_num ? sprintf(String, "M%u.", gEeprom.ScreenChannel[vfo_num] + 1) : sprintf(String,
-                                                                                                               "M%u",
-                                                                                                               gEeprom.ScreenChannel[vfo_num] +
-                                                                                                               1);
-            else
+            if (!inputting) {
+                const char *format = last_rx_vfo == vfo_num ? "M%u." : "M%u";
+                sprintf(String, format, gEeprom.ScreenChannel[vfo_num] + 1);
+            } else {
                 sprintf(String, "M%.3s", INPUTBOX_GetAscii());  // show the input text
+            }
             UI_PrintStringSmall(String, x, 0, line + 1);
         } else if (IS_FREQ_CHANNEL(gEeprom.ScreenChannel[vfo_num])) {    // frequency mode
             // show the frequency band number
             const unsigned int x = 2;
             char *buf = gEeprom.VfoInfo[vfo_num].pRX->Frequency < _1GHz_in_KHz ? "" : "+";
-            last_rx_vfo == vfo_num ? sprintf(String, "F%u%s.", 1 + gEeprom.ScreenChannel[vfo_num] - FREQ_CHANNEL_FIRST,
-                                             buf) : sprintf(String, "F%u%s",
-                                                            1 + gEeprom.ScreenChannel[vfo_num] - FREQ_CHANNEL_FIRST,
-                                                            buf);
+            const char *format = last_rx_vfo == vfo_num ? "F%u%s." : "F%u%s";
+            sprintf(String, format, 1 + gEeprom.ScreenChannel[vfo_num] - FREQ_CHANNEL_FIRST, buf);
             UI_PrintStringSmall(String, x, 0, line + 1);
         }
 #ifdef ENABLE_NOAA
@@ -742,14 +733,18 @@ if (!gDTMF_InputMode) {
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
                 DrawSmallAntennaAndBars(p_line1 + LCD_WIDTH, Level);
 #else
-                if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]) )
-                  {  DrawSmallAntennaAndBars(gFrameBuffer[2]+LCD_WIDTH, Level);
-                         audio_keep_flag=true;
-                  }
-
-else
-                DrawSmallAntennaAndBars(p_line1 + LCD_WIDTH, Level);
-
+                if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])) {
+                    if (!gDTMF_IsTx
+                        && gDTMF_CallState != DTMF_CALL_STATE_CALL_OUT
+                        && gDTMF_CallState != DTMF_CALL_STATE_RECEIVED
+                        && gDTMF_CallState != DTMF_CALL_STATE_RECEIVED_STAY
+                    ) {
+                        DrawSmallAntennaAndBars(gFrameBuffer[2] + LCD_WIDTH, Level);
+                        audio_keep_flag = true;
+                    }
+                } else {
+                    DrawSmallAntennaAndBars(p_line1 + LCD_WIDTH, Level);
+                }
 #endif
             }
         }
@@ -778,30 +773,28 @@ else
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
         UI_PrintStringSmall(s, LCD_WIDTH + 24, 0, line + 1); //中文信道1
 #else
-        if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])       )
-        UI_PrintStringSmall(s, LCD_WIDTH +0, 0, line + 1); //中文信道1
+        if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
+            UI_PrintStringSmall(s, LCD_WIDTH + 0, 0, line + 1); //中文信道1
         else
-        UI_PrintStringSmall(s, LCD_WIDTH + 24, 0, line + 1); //中文信道1
+            UI_PrintStringSmall(s, LCD_WIDTH + 24, 0, line + 1); //中文信道1
 
 
+        const bool bFlagMr = IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]) && !(FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num) && !(gCurrentFunction == FUNCTION_TRANSMIT && activeTxVFO == vfo_num);
+        const bool bFlagFreq = !IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]);
 
 #endif
         if (state == VFO_STATE_NORMAL || state == VFO_STATE_ALARM) {    // show the TX power
 
-
-
             const char pwr_list[][2] = {"L", "M", "H"};
             const unsigned int i = vfoInfo->OUTPUT_POWER % 3;
-
 
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
             UI_PrintStringSmall(pwr_list[i], LCD_WIDTH + 46, 0, line + 1); //中文信道1
 #else
 
-            if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])  &&!(FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num  )   &&!( gCurrentFunction == FUNCTION_TRANSMIT&&activeTxVFO == vfo_num) )
-
-            UI_PrintStringSmall(pwr_list[i], LCD_WIDTH + 9, 0, line -1); //中文信道1
-            else if(!IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]) )
+            if (bFlagMr)
+                UI_PrintStringSmall(pwr_list[i], LCD_WIDTH + 9, 0, line - 1); //中文信道1
+            else if (bFlagFreq)
                 UI_PrintStringSmall(pwr_list[i], LCD_WIDTH + 46, 0, line + 1); //中文信道1
 
 #endif
@@ -815,10 +808,10 @@ else
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
             UI_PrintStringSmall(dir_list[i], LCD_WIDTH + 54, 0, line + 1);//中文信道1
 #else
-            if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])   &&!(FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num  )    &&!( gCurrentFunction == FUNCTION_TRANSMIT&&activeTxVFO == vfo_num)  )
-                    UI_PrintStringSmall(dir_list[i], LCD_WIDTH + 17, 0, line - 1);//中文信道1
-                            else if(!IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]) )
-                    UI_PrintStringSmall(dir_list[i], LCD_WIDTH + 54, 0, line + 1);//中文信道1
+            if (bFlagMr)
+                UI_PrintStringSmall(dir_list[i], LCD_WIDTH + 17, 0, line - 1); //中文信道1
+            else if (bFlagFreq)
+                UI_PrintStringSmall(dir_list[i], LCD_WIDTH + 54, 0, line + 1); //中文信道1
 #endif
         }
 
@@ -826,45 +819,39 @@ else
         if (vfoInfo->FrequencyReverse) {
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
             UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1);//中文信道1
-
 #else
-            if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])    &&!(FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num  )    &&!( gCurrentFunction == FUNCTION_TRANSMIT&&activeTxVFO == vfo_num)      )
-                    UI_PrintStringSmall("R", LCD_WIDTH + 24, 0, line - 1);//中文信道1
-                    else if(!IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
-                        UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1);//中文信道1
+            if (bFlagMr)
+                UI_PrintStringSmall("R", LCD_WIDTH + 24, 0, line - 1); //中文信道1
+            else if (bFlagFreq)
+                UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1); //中文信道1
 
 #endif
         }
-        {    // show the narrow band symbol
+        {
+            // show the narrow band symbol
             if (vfoInfo->CHANNEL_BANDWIDTH == BANDWIDTH_NARROW) {
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
-
                 UI_PrintStringSmall("N", LCD_WIDTH + 70, 0, line + 1);
 #else
-                if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))        UI_PrintStringSmall("N", LCD_WIDTH + 21, 0, line + 1);
-
-            else UI_PrintStringSmall("N", LCD_WIDTH + 70, 0, line + 1);
-
-
-
+                if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
+                    UI_PrintStringSmall("N", LCD_WIDTH + 21, 0, line + 1);
+                else
+                    UI_PrintStringSmall("N", LCD_WIDTH + 70, 0, line + 1);
 #endif
             }
         }
 #ifdef ENABLE_DTMF_CALLING
         // show the DTMF decoding symbol
-        if (vfoInfo->DTMF_DECODING_ENABLE || gSetting_KILLED)
-            {
+        if (vfoInfo->DTMF_DECODING_ENABLE || gSetting_KILLED) {
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
             UI_PrintStringSmall("DTMF", LCD_WIDTH + 78, 0, line + 1);//中文信道1
 #else
-
-            if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])        )
-            UI_PrintStringSmall("D", LCD_WIDTH + 105, 0, line + 1);//中文信道1
-        else
-            UI_PrintStringSmall("DTMF", LCD_WIDTH + 78, 0, line + 1);//中文信道1
+            if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
+                UI_PrintStringSmall("D", LCD_WIDTH + 105, 0, line + 1); //中文信道1
+            else
+                UI_PrintStringSmall("DTMF", LCD_WIDTH + 78, 0, line + 1); //中文信道1
 #endif
-
-}
+        }
 
 #endif
         // show the audio scramble symbol
@@ -872,15 +859,12 @@ else
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
             UI_PrintStringSmall("ENC", LCD_WIDTH + 106, 0, line + 1);//中文信道1
 #else
-            if(IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num])        )
-            UI_PrintStringSmall("E", LCD_WIDTH + 29, 0, line +1);//中文信道1 ok
+            if (IS_MR_CHANNEL(gEeprom.ScreenChannel[vfo_num]))
+                UI_PrintStringSmall("E", LCD_WIDTH + 29, 0, line + 1); //中文信道1 ok
             else
-                UI_PrintStringSmall("ENC", LCD_WIDTH + 106, 0, line + 1);//中文信道1
+                UI_PrintStringSmall("ENC", LCD_WIDTH + 106, 0, line + 1); //中文信道1
 #endif
-
         }
-
-
     }
 #ifdef ENABLE_AGC_SHOW_DATA
     center_line = CENTER_LINE_IN_USE;

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -979,7 +979,7 @@ void UI_DisplayMenu(void) {
 //
 #if ENABLE_CHINESE_FULL == 4 && !defined(ENABLE_PINYIN) && !defined(ENABLE_ENGLISH)
 
-                    else if (CHINESE_JUDGE(tmp_name, strlen(tmp_name))) {
+                else if (CHINESE_JUDGE(tmp_name, strlen(tmp_name))) {
                     edit_index = -1;
                 }else if (!CHINESE_JUDGE(tmp_name, strlen(tmp_name))) {    // show the channel name being edited
 #else
@@ -1016,15 +1016,13 @@ void UI_DisplayMenu(void) {
                                 sum_pxl += 7;
                         }
                         uint8_t add_point = edit_chn[edit_index] == 1 ? 6 : 3;
-                        gFrameBuffer[4][menu_item_x1 - 12 + sum_pxl +
+
+                        uint8_t pointY = menu_item_x1 - 12 + sum_pxl +
                                         (((menu_item_x2 - menu_item_x1 + 12) -
-                                          (7 * (MAX_EDIT_INDEX - 2 * cnt_chn) + 13 * cnt_chn)) + 1) / 2 + add_point] |=
-                                3 << 6;
-                        gFrameBuffer[4][menu_item_x1 - 12 + sum_pxl +
-                                        (((menu_item_x2 - menu_item_x1 + 12) -
-                                          (7 * (MAX_EDIT_INDEX - 2 * cnt_chn) + 13 * cnt_chn)) + 1) / 2 + add_point +
-                                        1] |=
-                                3 << 6;
+                                          (7 * (MAX_EDIT_INDEX - 2 * cnt_chn) + 13 * cnt_chn)) + 1) / 2 + add_point;
+
+                        gFrameBuffer[4][pointY] |= 3 << 6;
+                        gFrameBuffer[4][pointY + 1] |= 3 << 6;
 #else
 
                         gFrameBuffer[4][menu_item_x1 - 12 + 7 * edit_index +
@@ -1050,9 +1048,9 @@ void UI_DisplayMenu(void) {
 
                             if (INPUT_STAGE >= 1)//显示拼音
                             {
-  uint8_t num=(PINYIN_NUM_SELECT ) / 3;
-                    if ((PINYIN_NOW_NUM + 2) / 3 >1+num )memcpy(&gFrameBuffer[1][123], BITMAP_ARRAY_DOWN, 5);
-                    if (num)memcpy(&gFrameBuffer[0][123], BITMAP_ARRAY_UP, 5);
+                                uint8_t num = (PINYIN_NUM_SELECT) / 3;
+                                if ((PINYIN_NOW_NUM + 2) / 3 > 1 + num)memcpy(&gFrameBuffer[1][123], BITMAP_ARRAY_DOWN, 5);
+                                if (num)memcpy(&gFrameBuffer[0][123], BITMAP_ARRAY_UP, 5);
 
                                 if (PINYIN_SEARCH_MODE == 1)//准确的组合
                                 {
@@ -1060,10 +1058,8 @@ void UI_DisplayMenu(void) {
 
 
 //OK
-                                    uint8_t HAVE_PINYIN =
-                                            PINYIN_NOW_NUM - PINYIN_NUM_SELECT / 3 * 3 > 3 ? 3 : PINYIN_NOW_NUM -
-                                                                                                 PINYIN_NUM_SELECT / 3 *
-                                                                                                 3;//目前有多少个拼音
+                                    //目前有多少个拼音
+                                    uint8_t HAVE_PINYIN = PINYIN_NOW_NUM - num * 3 > 3 ? 3 : PINYIN_NOW_NUM - num * 3;
 
 //OK
 //                                    show_uint32(PINYIN_NOW_NUM,0);

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -964,7 +964,9 @@ void UI_DisplayMenu(void) {
                 char tmp_name[17] = {0};
                 SETTINGS_FetchChannelName(tmp_name, gSubMenuSelection);
 
-                if (!gIsInSubMenu || edit_index < 0) {    // show the channel name
+                if (!gIsInSubMenu)
+                    edit_index = -1;
+                if (edit_index < 0) {    // show the channel name
                     SETTINGS_FetchChannelName(String, gSubMenuSelection);
                     char *pPrintStr = String[0] ? String : "--";
 #if ENABLE_CHINESE_FULL == 4 && !defined(ENABLE_ENGLISH)


### PR DESCRIPTION
Hi losehu，PR详情如下：
1. 优化部分代码，修复上次合并后HS固件overflow编译不通过的问题
2. 格式化部分代码，增加可读性
3. 修复一个拼音输入法bug：可选拼音组合大于一页(3个)时，选择第二页的组合，然后按`Exit`删除部分拼音输入，当新的可选组合不足两页时会死机  :(
4. 修复dtmf显示bug：信道模式下，显示dtmf信息时，如果此时按ptt键，dtmf信息会与小天线图标重合，见下图
![QQ_1725459532906](https://github.com/user-attachments/assets/7caf26ff-13a9-426f-9cd1-a26531e8734e)
![QQ_1725459592043](https://github.com/user-attachments/assets/5db08fdd-6e99-43af-88cc-089f298e2114)

5. 升级 workflow action 版本

That's all, thank you for reading.

This is **_BI1UTY_**, 73!

