### PR TITLE
New Feature: Add T Mode

### DIFF
--- a/app/main.c
+++ b/app/main.c
@@ -247,7 +247,7 @@ gBeepToPlay = BEEP_500HZ_60MS_DOUBLE_BEEP_OPTIONAL;
             break;
 
         case KEY_8:
-            gTxVfo->FrequencyReverse = gTxVfo->FrequencyReverse == false;
+            gTxVfo->FrequencyReverse = ++gTxVfo->FrequencyReverse % 3;
             gRequestSaveChannel = 1;
             break;
 

--- a/app/menu.c
+++ b/app/menu.c
@@ -989,9 +989,9 @@ void MENU_ShowCurrentSetting(void) {
             break;
 #ifdef ENABLE_CUSTOM_SIDEFUNCTIONS
 
-            case MENU_W_N:
-                gSubMenuSelection = gTxVfo->CHANNEL_BANDWIDTH;
-                break;
+        case MENU_W_N:
+            gSubMenuSelection = gTxVfo->CHANNEL_BANDWIDTH;
+            break;
 #endif
         case MENU_SCR:
             gSubMenuSelection = gTxVfo->SCRAMBLING_TYPE;
@@ -1126,13 +1126,13 @@ void MENU_ShowCurrentSetting(void) {
             gSubMenuSelection = gEeprom.DTMF_SIDE_TONE;
             break;
 #ifdef ENABLE_DTMF_CALLING
-            case MENU_D_RSP:
-                gSubMenuSelection = gEeprom.DTMF_DECODE_RESPONSE;
-                break;
+        case MENU_D_RSP:
+            gSubMenuSelection = gEeprom.DTMF_DECODE_RESPONSE;
+            break;
 
-            case MENU_D_HOLD:
-                gSubMenuSelection = gEeprom.DTMF_auto_reset_time;
-                break;
+        case MENU_D_HOLD:
+            gSubMenuSelection = gEeprom.DTMF_auto_reset_time;
+            break;
 #endif
         case MENU_D_PRE:
             gSubMenuSelection = gEeprom.DTMF_PRELOAD_TIME / 10;
@@ -1148,21 +1148,21 @@ void MENU_ShowCurrentSetting(void) {
 #ifdef ENABLE_DTMF_CALLING
 #ifdef ENABLE_CUSTOM_SIDEFUNCTIONS
 
-            case MENU_D_DCD:
-                gSubMenuSelection = gTxVfo->DTMF_DECODING_ENABLE;
-                break;
+        case MENU_D_DCD:
+            gSubMenuSelection = gTxVfo->DTMF_DECODING_ENABLE;
+            break;
 #endif
-            case MENU_D_LIST:
-                gSubMenuSelection = gDTMF_chosen_contact + 1;
-                break;
+        case MENU_D_LIST:
+            gSubMenuSelection = gDTMF_chosen_contact + 1;
+            break;
 #endif
         case MENU_D_LIVE_DEC:
             gSubMenuSelection = gSetting_live_DTMF_decoder;
             break;
 #if ENABLE_CHINESE_FULL == 4
-            case MENU_PONMSG:
-                gSubMenuSelection = gEeprom.POWER_ON_DISPLAY_MODE;
-                break;
+        case MENU_PONMSG:
+            gSubMenuSelection = gEeprom.POWER_ON_DISPLAY_MODE;
+            break;
 #endif
         case MENU_ROGER:
             gSubMenuSelection = gEeprom.ROGER;
@@ -1173,9 +1173,9 @@ void MENU_ShowCurrentSetting(void) {
 //			break;
 
 #ifdef ENABLE_AM_FIX
-            case MENU_AM_FIX:
-                gSubMenuSelection = gSetting_AM_fix;
-                break;
+        case MENU_AM_FIX:
+            gSubMenuSelection = gSetting_AM_fix;
+            break;
 #endif
 
 #ifdef ENABLE_AM_FIX_TEST1
@@ -1237,29 +1237,28 @@ void MENU_ShowCurrentSetting(void) {
             break;
 
 #ifdef ENABLE_CUSTOM_SIDEFUNCTIONS
-            case MENU_F1SHRT:
-            case MENU_F1LONG:
-            case MENU_F2SHRT:
-            case MENU_F2LONG:
-            case MENU_MLONG:
-            {
-                uint8_t * fun[]= {
-                    &gEeprom.KEY_1_SHORT_PRESS_ACTION,
-                    &gEeprom.KEY_1_LONG_PRESS_ACTION,
-                    &gEeprom.KEY_2_SHORT_PRESS_ACTION,
-                    &gEeprom.KEY_2_LONG_PRESS_ACTION,
-                    &gEeprom.KEY_M_LONG_PRESS_ACTION};
-                uint8_t id = *fun[UI_MENU_GetCurrentMenuId()-MENU_F1SHRT];
+        case MENU_F1SHRT:
+        case MENU_F1LONG:
+        case MENU_F2SHRT:
+        case MENU_F2LONG:
+        case MENU_MLONG: {
+            uint8_t *fun[] = {
+                &gEeprom.KEY_1_SHORT_PRESS_ACTION,
+                &gEeprom.KEY_1_LONG_PRESS_ACTION,
+                &gEeprom.KEY_2_SHORT_PRESS_ACTION,
+                &gEeprom.KEY_2_LONG_PRESS_ACTION,
+                &gEeprom.KEY_M_LONG_PRESS_ACTION
+            };
+            uint8_t id = *fun[UI_MENU_GetCurrentMenuId() - MENU_F1SHRT];
 
-                for(int i = 0; i <gSubMenu_SIDEFUNCTIONS_size; i++) {
-                    if(gSubMenu_SIDEFUNCTIONS[i].id==id) {
-                        gSubMenuSelection = i;
-                        break;
-                    }
-
+            for (int i = 0; i < gSubMenu_SIDEFUNCTIONS_size; i++) {
+                if (gSubMenu_SIDEFUNCTIONS[i].id == id) {
+                    gSubMenuSelection = i;
+                    break;
                 }
-                break;
             }
+            break;
+        }
 #endif
 
         default:
@@ -1613,8 +1612,7 @@ void UPDATE_CHN()
 {
     uint8_t tmp[5];
 
-    EEPROM_ReadBuffer(
-            PINYIN_NOW_INDEX * 128 + 0X20000 + 16 + PINYIN_NUM_SELECT * 16 + 6, tmp, 5);
+    EEPROM_ReadBuffer(PINYIN_NOW_INDEX * 128 + 0X20000 + 16 + PINYIN_NUM_SELECT * 16 + 6, tmp, 5);
     CHN_NOW_ADD = tmp[1] | tmp[2] << 8 | tmp[3] << 16 | tmp[4] << 24;
     CHN_NOW_NUM = tmp[0];
     CHN_NOW_PAGE = 0;
@@ -1957,7 +1955,7 @@ static void MENU_Key_UP_DOWN(bool bKeyPressed, bool bKeyHeld, int8_t Direction) 
         }
 #ifdef ENABLE_MDC1200
 #ifdef ENABLE_MDC1200_EDIT
-        else if (UI_MENU_GetCurrentMenuId() == MENU_MDC_ID) {
+        if (UI_MENU_GetCurrentMenuId() == MENU_MDC_ID) {
             if (bKeyPressed && edit_index < 4) {
                 char c = edit[edit_index] + Direction;
                 if (c < '0')c = 'F';

--- a/app/uart.c
+++ b/app/uart.c
@@ -426,7 +426,7 @@ static void CMD_052F(const uint8_t *pBuffer) {
     gEeprom.CROSS_BAND_RX_TX = CROSS_BAND_OFF;
     gEeprom.RX_VFO = 0;
     gEeprom.DTMF_SIDE_TONE = false;
-    gEeprom.VfoInfo[0].FrequencyReverse = false;
+    gEeprom.VfoInfo[0].FrequencyReverse = 0;
     gEeprom.VfoInfo[0].pRX = &gEeprom.VfoInfo[0].freq_config_RX;
     gEeprom.VfoInfo[0].pTX = &gEeprom.VfoInfo[0].freq_config_TX;
     gEeprom.VfoInfo[0].TX_OFFSET_FREQUENCY_DIRECTION = TX_OFFSET_FREQUENCY_DIRECTION_OFF;

--- a/radio.h
+++ b/radio.h
@@ -109,7 +109,7 @@ typedef struct VFO_Info_t
     STEP_Setting_t STEP_SETTING;
     uint8_t        OUTPUT_POWER;
     uint8_t        TXP_CalculatedSetting;
-    bool           FrequencyReverse;
+    uint8_t        FrequencyReverse;
 
     uint8_t        SCRAMBLING_TYPE;
     uint8_t        CHANNEL_BANDWIDTH;

--- a/settings.c
+++ b/settings.c
@@ -680,7 +680,9 @@ void SETTINGS_SaveChannel(uint8_t Channel, uint8_t VFO, const VFO_Info_t *pVFO, 
                       | (pVFO->BUSY_CHANNEL_LOCK << 4)
                       | (pVFO->OUTPUT_POWER      << 2)
                       | (pVFO->CHANNEL_BANDWIDTH << 1)
-                      | (pVFO->FrequencyReverse  << 0);
+                      | (pVFO->FrequencyReverse & 1u)
+                      | (1u << 5)
+                      | (pVFO->FrequencyReverse  << 6);
         State._8[5] = ((pVFO->DTMF_PTT_ID_TX_MODE & 7u) << 1)
 #ifdef ENABLE_DTMF_CALLING
             | ((pVFO->DTMF_DECODING_ENABLE & 1u) << 0)

--- a/ui/main.c
+++ b/ui/main.c
@@ -817,13 +817,14 @@ void UI_DisplayMain(void) {
 
         // show the TX/RX reverse symbol
         if (vfoInfo->FrequencyReverse) {
+            char *flag = vfoInfo->FrequencyReverse == 1 ? "R" : "T";
 #if ENABLE_CHINESE_FULL != 4 || defined(ENABLE_ENGLISH)
-            UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1);//中文信道1
+            UI_PrintStringSmall(flag, LCD_WIDTH + 62, 0, line + 1);//中文信道1
 #else
             if (bFlagMr)
-                UI_PrintStringSmall("R", LCD_WIDTH + 24, 0, line - 1); //中文信道1
+                UI_PrintStringSmall(flag, LCD_WIDTH + 24, 0, line - 1); //中文信道1
             else if (bFlagFreq)
-                UI_PrintStringSmall("R", LCD_WIDTH + 62, 0, line + 1); //中文信道1
+                UI_PrintStringSmall(flag, LCD_WIDTH + 62, 0, line + 1); //中文信道1
 
 #endif
         }

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -617,11 +617,12 @@ void UI_DisplayMenu(void) {
 #endif
 
 #ifdef ENABLE_PINYIN //拼音取消显示
-    if (!(UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME && gIsInSubMenu && gIsInSubMenu && edit_index >= 0))
+    const bool isInPinyin = UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME && gIsInSubMenu && edit_index >= 0;
+    if (!isInPinyin)
 #endif
     UI_PrintStringSmall(String, 2, 0, 6);
 #ifdef ENABLE_PINYIN//拼音取消显示
-    if (!(UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME && gIsInSubMenu && edit_index >= 0))
+    if (!isInPinyin)
 #endif
 
 
@@ -921,34 +922,33 @@ void UI_DisplayMenu(void) {
             break;
         }
 #ifdef ENABLE_MDC1200
-            case MENU_MDC_ID:
-            {
+        case MENU_MDC_ID: {
 #ifdef ENABLE_MDC1200_EDIT
-                    if(gIsInSubMenu){    // show the channel name being edited
-                    UI_PrintStringSmall(edit, menu_item_x1, menu_item_x2, 3);
-                    if (edit_index < 4)
-                        UI_PrintStringSmall("^", menu_item_x1+(((menu_item_x2 - menu_item_x1) - (28)) + 1) / 2 + (7 * edit_index), 0, 4);  // show the cursor
-                }else
-                    {
+            if (gIsInSubMenu) {
+                // show the channel name being edited
+                UI_PrintStringSmall(edit, menu_item_x1, menu_item_x2, 3);
+                if (edit_index < 4)
+                    UI_PrintStringSmall("^", menu_item_x1 + (((menu_item_x2 - menu_item_x1) - (28)) + 1) / 2 + (7 * edit_index), 0, 4); // show the cursor
+            } else {
 #endif
-                    sprintf(String, "%04X", gEeprom.MDC1200_ID); // %04X确保输出是4个字符长度的十六进制数
-                    UI_PrintStringSmall(String, menu_item_x1, menu_item_x2, 3);//4
+                sprintf(String, "%04X", gEeprom.MDC1200_ID); // %04X确保输出是4个字符长度的十六进制数
+                UI_PrintStringSmall(String, menu_item_x1, menu_item_x2, 3); //4
 
 #ifdef ENABLE_MDC1200_EDIT
 
-                    edit_index = -1;
-                    edit[0]=String[0];
-                    edit[1]=String[1];
-                    edit[2]=String[2];
-                    edit[3]=String[3];
-                      edit[4]='\0';
+                edit_index = -1;
+                edit[0] = String[0];
+                edit[1] = String[1];
+                edit[2] = String[2];
+                edit[3] = String[3];
+                edit[4] = '\0';
 #endif
 #ifdef ENABLE_MDC1200_EDIT
-                    }
-#endif
-                already_printed = true;
-                break;
             }
+#endif
+            already_printed = true;
+            break;
+        }
 #endif
         case MENU_MEM_NAME: { //输入法显示
 //ok
@@ -1069,7 +1069,7 @@ void UI_DisplayMenu(void) {
 //                                    show_uint32(HAVE_PINYIN,1);
                                     for (int j = 0; j < HAVE_PINYIN; ++j) {
                                         EEPROM_ReadBuffer(
-                                                PINYIN_NOW_INDEX * 128 + 0X20000 + 16 + PINYIN_NUM_SELECT / 3 * 3 * 16 +
+                                                PINYIN_NOW_INDEX * 128 + 0X20000 + 16 + num * 3 * 16 +
                                                 j * 16, tmp, 6);
                                         memcpy(&String[6 * j], tmp, 6);//0 1 2 3 4 5
                                     }
@@ -1135,7 +1135,7 @@ void UI_DisplayMenu(void) {
                                     tmp[0] ='5', tmp[4] = '6', tmp[8] = '7', tmp[12] = '8';
                                     tmp[2] -= 32, tmp[6] -= 32, tmp[10] -= 32, tmp[14] -= 32;
                                 }
-                                                                    UI_PrintStringSmall(tmp, 0, 127, 1);
+                                UI_PrintStringSmall(tmp, 0, 127, 1);
 
                             }
                         }
@@ -1518,8 +1518,8 @@ void UI_DisplayMenu(void) {
          #endif
          UI_MENU_GetCurrentMenuId() == MENU_DEL_CH) && gAskForConfirmation) {    // display confirmation
         char *pPrintStr = (gAskForConfirmation == 1) ? "SURE?" : "WAIT!";
-        if ((UI_MENU_GetCurrentMenuId() == MENU_MEM_CH || UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME ||
-             UI_MENU_GetCurrentMenuId() == MENU_DEL_CH) && gAskForConfirmation)
+        if (UI_MENU_GetCurrentMenuId() == MENU_MEM_CH || UI_MENU_GetCurrentMenuId() == MENU_MEM_NAME ||
+             UI_MENU_GetCurrentMenuId() == MENU_DEL_CH)
             UI_PrintStringSmall(pPrintStr, menu_item_x1 - 12, menu_item_x2, 5);
         else UI_PrintStringSmall(pPrintStr, menu_item_x1, menu_item_x2, 5);
 


### PR DESCRIPTION
Hi losehu，PR详情如下：

1.  优化部分代码
2.  格式化部分代码，增加可读性
3.  增加T模式，宝峰uv5rh和森海克斯8600都有此模式，某些场景下比较实用。
`F+8`或长按`8`键，循环设置  `正常模式`-->`R` --> `T`。未设置频差方向和频差频率的情况下，三种模式没有区别，设置频差方向和频差频率的情况下，区别如下：
&nbsp;- 正常模式：正常按频差设置收发
&nbsp;- R：倒频模式，颠倒正常模式的收发设置
&nbsp;- T：以正常模式的接收频率设置进行收发
<br>显示效果如下图：
![QQ_1725703936060](https://github.com/user-attachments/assets/07f6ace2-422a-493e-958f-755c9cffd78e)
![QQ_1725703953974](https://github.com/user-attachments/assets/4f065de2-00b6-430a-8857-3d4950300c8d)
<br>实现思路：
原始读取倒频设置的逻辑如下：
https://github.com/losehu/uv-k5-firmware-custom/blob/0f66c4fcf943daf5ce69e77a8e43bad7b4abfd9a/radio.c#L294-L305
存储倒频设置的这个字节中保存了4个信息，由低到高位分别为：
&nbsp;- 1bit：是否倒频
&nbsp;- 2bit：宽窄带
&nbsp;- 3-4bit：发射功率
&nbsp;- 5bit：遇忙禁发
<br>利用空闲的6-8bit扩展出`T`模式，为了兼容原有设置，6bit作为标识位，7-8bit存储模式，原有设置中6-8bit都是`0`，所以新的读取逻辑为，如果6bit为0，则读取第1bit的原有设置，否则读取第7-8bit的数据，7-8bit的数据对应关系为：
&nbsp;- `0b00`：正常模式
&nbsp;- `0b01`：R模式
&nbsp;- `0b10`：T模式
<br>新的读取倒频模式的逻辑：
https://github.com/losehu/uv-k5-firmware-custom/blob/856b1d6c3a21a09e4cace1627ea6998fbcb40886/radio.c#L294-L305
<br>当进行设置存储的操作后，6bit标识位改变为`1`，存储后再读取模式信息，则会读取7-8bit的信息。存储逻辑为：
https://github.com/losehu/uv-k5-firmware-custom/blob/856b1d6c3a21a09e4cace1627ea6998fbcb40886/settings.c#L679-L685
模式为`正常`或`R`时，同时会写入第1bit以兼容读写频操作，模式为`T`时，读写频会显示`正常`模式。

That's all, thank you for reading.

This is **_BI1UTY_**, 73!