### PR TITLE
Fix a dtmf bug

### DIFF
--- a/app/dtmf.c
+++ b/app/dtmf.c
@@ -209,6 +209,7 @@ void DTMF_clear_input_box(void) {
     memset(gDTMF_InputBox, 0, sizeof(gDTMF_InputBox));
     gDTMF_InputBox_Index = 0;
     gDTMF_InputMode = false;
+    gPttWasReleased = false;
 }
 
 void DTMF_Append(const char code) {

--- a/app/main.c
+++ b/app/main.c
@@ -506,8 +506,7 @@ static void MAIN_Key_EXIT(bool bKeyPressed, bool bKeyHeld) {
 
         if (gInputBoxIndex > 0 || gDTMF_InputBox_Index > 0 ||
             gDTMF_InputMode) {    // cancel key input mode (channel/frequency entry)
-            gDTMF_InputMode = false;
-            gDTMF_InputBox_Index = 0;
+            DTMF_clear_input_box();
             memset(gDTMF_String, 0, sizeof(gDTMF_String));
             gInputBoxIndex = 0;
             gRequestDisplayScreen = DISPLAY_MAIN;


### PR DESCRIPTION
Hi losehu，此PR修复bug如下：

以下两个情况在操作后按下的第一个按键无效(`Menu`,`0-9`,`*`,`F`):

1. 按`*`键进入DTMF拨号功能，等待8秒自动退出
2. 按`*`键进入DTMF拨号功能，输入内容后按`ptt`键发射，再按`*`键后不做输入直接按`ptt`发射

That's all, thank you for reading.

This is **_BI1UTY_**, 73!
