### PR TITLE
Fix dtmf contacts chinese display

### DIFF
--- a/app/dtmf.c
+++ b/app/dtmf.c
@@ -113,8 +113,12 @@ bool DTMF_GetContact(const int Index, char *pContact)
 
     EEPROM_ReadBuffer(0x1C00 + (Index * 16), pContact, 16);
 
+#if ENABLE_CHINESE_FULL == 4
+    return pContact[0] != 0xff;
+#else
     // check whether the first character is printable or not
     return (pContact[0] >= ' ' && pContact[0] < 127);
+#endif
 }
 bool DTMF_FindContact(const char *pContact, char *pResult)
 {


### PR DESCRIPTION
Hi losehu，PR详情如下：

完善GB2312版本对于DTMF联系人的中文显示，目前只有第一个字符为非中文才能正常显示，否则显示NULL。
[K5Web](https://k5.vicicode.com/#/chirp/base) 对DTMF 联系人的读写我已经提交了PR给 @silenty4ng  ,https://github.com/silenty4ng/k5web/pull/28#issue-2519578205

![QQ_1726059105146](https://github.com/user-attachments/assets/c880b8e1-cc9f-4b86-9baf-f907a7a3090b)
![QQ_1726059122321](https://github.com/user-attachments/assets/88819acc-4001-4b25-8590-5da6acb971d2)
![QQ_1726059133941](https://github.com/user-attachments/assets/7dc26d23-b4e4-4668-be28-90207fa70e9c)


That's all, thank you for reading, this is **_BI1UTY_**, 73!

