### PR TITLE
Fix pinyin bug

### DIFF
--- a/ui/menu.c
+++ b/ui/menu.c
@@ -998,20 +998,21 @@ void UI_DisplayMenu(void) {
 //#endif
 
 #ifdef ENABLE_PINYIN
+                        uint8_t cnt_chn = 0;
                         for (int j = 0; j < MAX_EDIT_INDEX; ++j) {
                             if (edit[j] >= 0xb0 && j != MAX_EDIT_INDEX - 1) {
                                 edit_chn[j] = 1;
                                 j++;
                                 edit_chn[j] = 2;
+                                cnt_chn++;
                             } else edit_chn[j] = 0;
                         }
+
                         uint8_t sum_pxl = 0;
-                        uint8_t cnt_chn = 0;
                         for (int j = 0; j < edit_index; j++) {
                             if (edit_chn[j] == 1) {
                                 sum_pxl += 13;
                                 j++;
-                                cnt_chn++;
                             } else
                                 sum_pxl += 7;
                         }

--- a/ui/menu.c
+++ b/ui/menu.c
@@ -1021,8 +1021,8 @@ void UI_DisplayMenu(void) {
                                         (((menu_item_x2 - menu_item_x1 + 12) -
                                           (7 * (MAX_EDIT_INDEX - 2 * cnt_chn) + 13 * cnt_chn)) + 1) / 2 + add_point;
 
-                        gFrameBuffer[4][pointY] |= 3 << 6;
-                        gFrameBuffer[4][pointY + 1] |= 3 << 6;
+                        gFrameBuffer[4][pointY] |= 3 << 5;
+                        gFrameBuffer[4][pointY + 1] |= 3 << 5;
 #else
 
                         gFrameBuffer[4][menu_item_x1 - 12 + 7 * edit_index +


### PR DESCRIPTION
Hi losehu，PR详情如下：

1. 拼音输入光标点上移一个像素，避免与待选汉字连显
![QQ_1726380760272](https://github.com/user-attachments/assets/d0955f41-844f-4746-bd3a-c0314191d679)
![QQ_1726380787820](https://github.com/user-attachments/assets/50adced5-9311-43aa-b663-bf52a3154052)

2. 完善拼音输入光标点水平位置计算方法，尽量与对应文字居中显示
![QQ_1726393887097](https://github.com/user-attachments/assets/d5fcf916-0d33-49cb-b7bc-3d0215730fbd)
![QQ_1726393918117](https://github.com/user-attachments/assets/a0f01b5d-30e8-41ab-9ea1-7ffbc1fcdfcc)



That's all, thank you for reading, this is **_BI1UTY_**, 73!

