### PR TITLE
Fix main display bug

### DIFF
--- a/ui/main.c
+++ b/ui/main.c
@@ -489,10 +489,10 @@ void UI_DisplayMain(void) {
             }
         } else {    // receiving .. show the RX symbol
             mode = VFO_MODE_RX;
-            if (FUNCTION_IsRx() && gEeprom.RX_VFO == vfo_num) {
-                last_rx_vfo = vfo_num;
-                memcpy(gFrameBuffer[line + 0] + 14, BITMAP_RECV, sizeof(BITMAP_RECV));
-
+            if (FUNCTION_IsRx()) {
+                last_rx_vfo = gEeprom.RX_VFO;
+                if (gEeprom.RX_VFO == vfo_num)
+                    memcpy(gFrameBuffer[line + 0] + 14, BITMAP_RECV, sizeof(BITMAP_RECV));
             }
         }
 


### PR DESCRIPTION
Hi losehu，PR详情如下：

修复主界面显示bug，双守模式下，上面的信道接收信号后，信道号后面正常显示`.`，此时如果下面的信道开始接收信号，上下两个信道会同时显示`.`，直到下面信道信号接收停止。
![QQ_1726494887907](https://github.com/user-attachments/assets/28b6d41d-9b63-4136-95ed-94537d1e990f)




That's all, thank you for reading, this is **_BI1UTY_**, 73!

